### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.0+3] - May, 31, 2022
+
+* Automated dependency updates
+
+
 ## [2.0.0+2] - February 6th, 2022
 
 * Dependency updates
@@ -26,5 +31,6 @@
 ## [1.0.0] - November 2nd, 2021
 
 * Initial release
+
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
-name: grpc_protobuf_convert
-description: Simple converters to convert to / from Protobuf and Fixnum classes from Dart classes.
-version: 2.0.0+2
-homepage: https://github.com/peiffer-innovations/grpc_protobuf_convert
+name: 'grpc_protobuf_convert'
+description: 'Simple converters to convert to / from Protobuf and Fixnum classes from Dart classes.'
+version: '2.0.0+3'
+homepage: 'https://github.com/peiffer-innovations/grpc_protobuf_convert'
 
-environment:
-  sdk: ">=2.17.0 <3.0.0"
+environment: 
+  sdk: '>=2.17.0 <3.0.0'
 
-dependencies:
-  fixnum: ^1.0.0
-  grpc_googleapis: ^2.0.19
+dependencies: 
+  fixnum: '^1.0.1'
+  grpc_googleapis: '^2.0.20'
 
-dev_dependencies:
-  test: ^1.21.1
+dev_dependencies: 
+  test: '^1.21.1'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `fixnum`: 1.0.0 --> 1.0.1
  * `grpc_googleapis`: 2.0.19 --> 2.0.20


Analysis Successful

