### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.0+5] - June 28, 2022
+
+* Automated dependency updates
+
+
 ## [2.0.0+4] - June 21, 2022
 
 * Automated dependency updates
@@ -36,6 +41,7 @@
 ## [1.0.0] - November 2nd, 2021
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'grpc_protobuf_convert'
 description: 'Simple converters to convert to / from Protobuf and Fixnum classes from Dart classes.'
-version: '2.0.0+4'
+version: '2.0.0+5'
 homepage: 'https://github.com/peiffer-innovations/grpc_protobuf_convert'
 
 environment: 
@@ -8,7 +8,7 @@ environment:
 
 dependencies: 
   fixnum: '^1.0.1'
-  grpc_googleapis: '^2.0.20'
+  grpc_googleapis: '^2.0.21'
 
 dev_dependencies: 
-  test: '^1.21.2'
+  test: '^1.21.3'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `grpc_googleapis`: 2.0.20 --> 2.0.21

dev_dependencies:
  * `test`: 1.21.2 --> 1.21.3


Analysis Successful

