### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.0+7] - July 19, 2022
+
+* Automated dependency updates
+
+
 ## [2.0.0+6] - July 12, 2022
 
 * Automated dependency updates
@@ -46,6 +51,7 @@
 ## [1.0.0] - November 2nd, 2021
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'grpc_protobuf_convert'
 description: 'Simple converters to convert to / from Protobuf and Fixnum classes from Dart classes.'
-version: '2.0.0+6'
+version: '2.0.0+7'
 homepage: 'https://github.com/peiffer-innovations/grpc_protobuf_convert'
 
 environment: 
@@ -8,7 +8,7 @@ environment:
 
 dependencies: 
   fixnum: '^1.0.1'
-  grpc_googleapis: '^2.0.21'
+  grpc_googleapis: '^2.0.22'
 
 dev_dependencies: 
   test: '^1.21.4'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `grpc_googleapis`: 2.0.21 --> 2.0.22


Analysis Successful

