### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.1+1] - January 31, 2023
+
+* Automated dependency updates
+
+
 ## [2.0.1] - January 24th, 2023
 
 * Flutter 3.7
@@ -86,6 +91,7 @@
 ## [1.0.0] - November 2nd, 2021
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: 'grpc_protobuf_convert'
 description: 'Simple converters to convert to / from Protobuf and Fixnum classes from Dart classes.'
-version: '2.0.1'
+version: '2.0.1+1'
 homepage: 'https://github.com/peiffer-innovations/grpc_protobuf_convert'
 
-environment:
+environment: 
   sdk: '>=2.19.0 <4.0.0'
 
-dependencies:
-  fixnum: '^1.0.1'
-  grpc_googleapis: '^2.0.22'
+dependencies: 
+  fixnum: '^1.1.0'
+  grpc_googleapis: '^2.0.32'
 
-dev_dependencies:
+dev_dependencies: 
   test: '^1.22.2'
 
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `fixnum`: 1.0.1 --> 1.1.0
  * `grpc_googleapis`: 2.0.22 --> 2.0.32


Analysis Successful

